### PR TITLE
V1.1 Fixes - Add warning for VideoMaker and update links to VideoMaker YouTube video.

### DIFF
--- a/docs/source/how_to_demos.rst
+++ b/docs/source/how_to_demos.rst
@@ -92,7 +92,7 @@ iDaVIE provides an extensive video recording mode, with more detail available at
 
 .. raw:: html
 
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/sICpmbkUZnA?si=lnUaJ3pmPM65N6ct" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/Jh-1LdrYnI8?si=gzbQ8rWtNmOOK0YW" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 
 Desktop Selection

--- a/docs/source/videoMaker.rst
+++ b/docs/source/videoMaker.rst
@@ -98,3 +98,5 @@ Navigate to the file location where you stored the FFmpeg folder, select the :li
         style="width:100%;height:auto;">
 
 The exported video can be found in :literal:`Output/Video`, and will have the same filename as the IDVS with an additional time-stamp at the end for when the video was made.
+
+.. WARNING:: If the data cube is too zoomed in or out, this can affect the video and you may need to go into VR to change the level of zoom. If the nearest parts of the cube are cut-off when the camera enters it, then you are probably too zoomed out (the cube is too small). Conversely, if distant parts of the cube are cut-off, then you are probably too zoomed in (cube is too big).

--- a/docs/source/videoMaker.rst
+++ b/docs/source/videoMaker.rst
@@ -24,7 +24,7 @@ iDaVIE provides functionality that allows the user to capture perspectives withi
 
 .. raw:: html
 
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/sICpmbkUZnA?si=lnUaJ3pmPM65N6ct" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/Jh-1LdrYnI8?si=gzbQ8rWtNmOOK0YW" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 See :ref:`videomakerui` for an explanation of the UI elements used for this functionality.
 


### PR DESCRIPTION
Updates to the V1.1 branch of the documentation for VideoMaker.

### Changes
- Add warning to VideoMaker for level-of zoom affecting the video.
- Update links to the VideoMaker YouTube videos.